### PR TITLE
Upgrade templates for bootstrap 3.

### DIFF
--- a/ckanext/extrafields/ontario_theme_dataset.json
+++ b/ckanext/extrafields/ontario_theme_dataset.json
@@ -33,14 +33,14 @@
       "preset": "fluent_text",
       "required": "true",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       } 
     },
     {
       "field_name": "owner_org",
       "label": "Organization",
       "preset": "dataset_organization",
-      "classes": ["span8","form-group"]
+      "classes": ["col-md-12","form-group"]
     },
     {
       "field_name": "notes_translated",
@@ -60,7 +60,7 @@
       },
       "preset": "fluent_tags",
       "form_placeholder": "eg. economy, mental health, government",
-      "classes": ["span4"],
+      "classes": ["col-md-6"],
       "form_attrs": {
         "data-module": "autocomplete",
         "data-module-tags": "",
@@ -73,9 +73,9 @@
       "form_snippet": "license.html",
       "help_text": "License definitions and additional information can be found at http://opendefinition.org/",
       "form_attrs": {
-        "class": "span8"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "url",
@@ -84,9 +84,9 @@
       "display_property": "foaf:homepage",
       "display_snippet": "link.html",
       "form_attrs": {
-        "class": "span8"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "node_id",
@@ -97,9 +97,9 @@
       "form_placeholder": "4321",
       "validators": "ignore_missing int_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "version",
@@ -107,9 +107,9 @@
       "form_placeholder": "1.0",
       "validators": "ignore_missing unicode package_version_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "author",
@@ -117,9 +117,9 @@
       "form_placeholder": "Joe Bloggs",
       "display_property": "dc:creator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "author_email",
@@ -130,9 +130,9 @@
       "display_email_name_field": "author",
       "validators": "ignore_missing email_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "maintainer",
@@ -140,9 +140,9 @@
       "form_placeholder": "Joe Bloggs",
       "display_property": "dc:contributor",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "maintainer_email",
@@ -153,9 +153,9 @@
       "display_email_name_field": "maintainer",
       "validators": "ignore_missing email_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "maintainer_branch",
@@ -171,7 +171,10 @@
         "en": "Technical title",
         "fr": "Tecnical title"
       },      
-      "preset": "fluent_text"
+      "preset": "fluent_text",
+      "form_attrs": {
+        "class": "form-control"
+      }
     },
     {
       "field_name": "data_range_start",
@@ -182,9 +185,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "data_range_end",
@@ -195,9 +198,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "data_birth_date",
@@ -208,9 +211,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "opened_date",
@@ -221,9 +224,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "dataset_published_date",
@@ -234,9 +237,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "target_posting_date",
@@ -247,9 +250,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "assessment_date",
@@ -260,9 +263,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "contains_geographic_markers",
@@ -273,9 +276,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -301,9 +304,9 @@
       },
       "preset": "fluent_text",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "update_frequency",
@@ -314,9 +317,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "as_required",
@@ -420,9 +423,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "open",
@@ -463,9 +466,9 @@
       "preset": "select",
       "validators": "ignore_missing default(none) scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "commercial_sensitivity",
@@ -519,9 +522,9 @@
       },
       "preset": "fluent_markdown",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "comments",
@@ -531,9 +534,9 @@
       },
       "preset": "fluent_markdown",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "submission_type",
@@ -546,9 +549,9 @@
       "fieldset": 2,
       "fieldset_name": "Submissoin tracking",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "colby_candidate",
@@ -610,9 +613,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "data_identified_for_internal_sharing",
@@ -695,9 +698,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -724,9 +727,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -769,9 +772,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "plain_language_start_date",
@@ -782,9 +785,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "plain_language_end_date",
@@ -795,9 +798,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "final_review_date",
@@ -808,9 +811,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "with_co_date",
@@ -821,9 +824,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "met_service_standard",
@@ -834,9 +837,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -865,9 +868,9 @@
       "fieldset": 3,
       "fieldset_name": "Archive information",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -893,9 +896,9 @@
       },
       "preset": "fluent_markdown",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "date_removed",
@@ -906,9 +909,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "forwarding_url",
@@ -918,9 +921,9 @@
       },
       "validators": "ignore_missing",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "meets_update_frequency",
@@ -933,9 +936,9 @@
       "fieldset": 4,
       "fieldset_name": "Data quality",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -962,9 +965,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -991,9 +994,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -1020,9 +1023,9 @@
       "preset": "select",
       "validators": "boolean_validator",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "true",
@@ -1049,9 +1052,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "open",
@@ -1085,9 +1088,9 @@
       "form_placeholder": "eg. A1A 1A1",
       "validators": "ignore_missing",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "fiscal_year_format",
@@ -1098,9 +1101,9 @@
       "form_placeholder": "eg. yyyy-mm-dd",
       "validators": "ignore_missing",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "date_format",
@@ -1111,9 +1114,9 @@
       "form_placeholder": "eg. yyyy-mm-dd",
       "validators": "ignore_missing",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     },
     {
       "field_name": "time_series",
@@ -1124,9 +1127,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "all_data_is_in_one_file",
@@ -1160,9 +1163,9 @@
       "preset": "select",
       "validators": "ignore_missing scheming_choices",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"],
+      "classes": ["col-md-12"],
       "choices": [
         {
           "value": "yes",
@@ -1196,9 +1199,9 @@
       "preset": "date",
       "validators": "ignore_missing isodate convert_to_json_if_date",
       "form_attrs": {
-        "class": "span4"
+        "class": "form-control"
       },
-      "classes": ["span8"]
+      "classes": ["col-md-12"]
     }
   ],
   "resource_fields": [

--- a/ckanext/extrafields/templates/scheming/form_snippets/extrafields_fluent_title.html
+++ b/ckanext/extrafields/templates/scheming/form_snippets/extrafields_fluent_title.html
@@ -26,8 +26,8 @@ Future solutions may include:
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['span4'],
-    attrs={'data-module': 'slug-preview-target', 'class': 'span4'} if lang == h.extrafields_default_locale() else {'class': 'span4'},
+    classes=['col-md-6'],
+    attrs={'data-module': 'slug-preview-target', 'class': 'form-control'} if lang == h.extrafields_default_locale() else {'class': 'form-control'},
     is_required=h.scheming_field_required(field)
     ) %}
     {%- snippet 'scheming/form_snippets/fluent_help_text.html',

--- a/ckanext/extrafields/templates/scheming/form_snippets/fluent_markdown.html
+++ b/ckanext/extrafields/templates/scheming/form_snippets/fluent_markdown.html
@@ -9,8 +9,8 @@
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['span4'],
-    attrs=field.form_attrs or {'class': 'span4'},
+    classes=['col-md-6'],
+    attrs=field.form_attrs or {'class': 'col-md-6'},
     is_required=h.scheming_field_required(field)
     ) %}
     {%- snippet 'scheming/form_snippets/fluent_help_text.html',

--- a/ckanext/extrafields/templates/scheming/form_snippets/fluent_text.html
+++ b/ckanext/extrafields/templates/scheming/form_snippets/fluent_text.html
@@ -9,8 +9,8 @@
     value=data[field.field_name + '-' + lang]
         or data.get(field.field_name, {})[lang],
     error=errors[field.field_name + '-' + lang],
-    classes=['span4'],
-    attrs=field.form_attrs if 'form_attrs' in field else {'class': 'span4'},
+    classes=['col-md-6'],
+    attrs=field.form_attrs if 'form_attrs' in field else {'class': 'form-control'},
     is_required=h.scheming_field_required(field)
     ) %}
     {%- snippet 'scheming/form_snippets/fluent_help_text.html',

--- a/ckanext/extrafields/templates/scheming/form_snippets/organization.html
+++ b/ckanext/extrafields/templates/scheming/form_snippets/organization.html
@@ -15,7 +15,7 @@
   {% snippet "scheming/form_snippets/_organization_select.html",
     field=field,
     data=data,
-    classes=['span8'],
+    classes=['col-md-12'],
     errors=errors,
     organizations_available=h.organizations_available('create_dataset'),
     org_required=not h.check_config_permission('create_unowned_dataset')

--- a/ckanext/extrafields/templates/scheming/package/snippets/package_form.html
+++ b/ckanext/extrafields/templates/scheming/package/snippets/package_form.html
@@ -31,7 +31,7 @@ control-rows to align french and english fields side by side.
           <legend>{{ field.fieldset_name }}</legend>
       {%- endif -%}
 
-      <div class="controls controls-row">
+      <div class="controls row">
       {%- snippet 'scheming/snippets/form_field.html',
           field=field, data=data, errors=errors, licenses=c.licenses,
           entity_type='dataset', object_type=dataset_type -%}


### PR DESCRIPTION
Changes include:

- Make changes to templates and template related values in the schema to accommodate bootstrap 3.
- Moving to bootstrap 3 for CKAN 2.8 upgrade.