### PR TITLE
Resource size

### DIFF
--- a/ckanext/extrafields/templates/scheming/package/resource_read.html
+++ b/ckanext/extrafields/templates/scheming/package/resource_read.html
@@ -5,4 +5,9 @@
     <th scope="row">{{ _('Format') }}</th>
     <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
   </tr>
+  {# Add resource size if known. This extends scheming's template. #}
+  <tr>
+    <th scope="row">File size</th>
+    <td>{{ h.localised_filesize(res.size) if res.size else _('unknown size') }}</td>
+  </tr>
 {%- endblock -%}

--- a/ckanext/extrafields/templates/scheming/package/resource_read.html
+++ b/ckanext/extrafields/templates/scheming/package/resource_read.html
@@ -1,0 +1,8 @@
+{% ckan_extends %}
+
+{%- block resource_format -%}
+  <tr>
+    <th scope="row">{{ _('Format') }}</th>
+    <td>{{ res.mimetype_inner or res.mimetype or res.format or _('unknown') }}</td>
+  </tr>
+{%- endblock -%}


### PR DESCRIPTION
Add resource filesize to additional information on resource read page.

In the future this would be good to break out from this extension and include in the theme extension as this is going beyond adding additional fields with scheming.