### PR TITLE
Facets

### DIFF
--- a/ckanext/extrafields/plugin.py
+++ b/ckanext/extrafields/plugin.py
@@ -48,4 +48,5 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         '''Add new search facet (filter) for datasets.
         '''
         facets_dict['access_level'] = toolkit._('Access Level')
+        facets_dict['update_frequency'] = toolkit._('Update Frequency')
         return facets_dict

--- a/ckanext/extrafields/plugin.py
+++ b/ckanext/extrafields/plugin.py
@@ -18,6 +18,7 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.ITemplateHelpers)
+    plugins.implements(plugins.IFacets)
 
     def get_helpers(self):
         '''Register the helper to access the default local.
@@ -42,3 +43,9 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         # This plugin doesn't handle any special package types, it just
         # registers itself as the default (above).
         return []        
+
+    def dataset_facets(self, facets_dict, package_type):
+        '''Add new search facet (filter) for datasets.
+        '''
+        facets_dict['access_level'] = toolkit._('Access Level')
+        return facets_dict

--- a/ckanext/extrafields/templates/package/search.html
+++ b/ckanext/extrafields/templates/package/search.html
@@ -1,3 +1,11 @@
+{#
+
+Override CKAN's search.html to add new sorting options.
+
+#}
+
+{% ckan_extends %}
+
 {% block form %}
   {% set facets = {
     'fields': c.fields_grouped,
@@ -11,6 +19,7 @@
     (_('Name Ascending'), 'title_string asc'),
     (_('Name Descending'), 'title_string desc'),
     (_('Last Modified'), 'metadata_modified desc'),
+    (_('Recently Created'), 'dataset_published_date desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
   {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}

--- a/ckanext/extrafields/templates/package/search.html
+++ b/ckanext/extrafields/templates/package/search.html
@@ -1,0 +1,17 @@
+{% block form %}
+  {% set facets = {
+    'fields': c.fields_grouped,
+    'search': c.search_facets,
+    'titles': c.facet_titles,
+    'translated_fields': c.translated_fields,
+    'remove_field': c.remove_field }
+  %}
+  {% set sorting = [
+    (_('Relevance'), 'score desc, metadata_modified desc'),
+    (_('Name Ascending'), 'title_string asc'),
+    (_('Name Descending'), 'title_string desc'),
+    (_('Last Modified'), 'metadata_modified desc'),
+    (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
+  %}
+  {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+{% endblock %}

--- a/ckanext/extrafields/templates/snippets/facet_list.html
+++ b/ckanext/extrafields/templates/snippets/facet_list.html
@@ -6,6 +6,8 @@
 
 {% set hide_empty = true %}
 
+{% set fields = h.scheming_get_dataset_schema('dataset')['dataset_fields'] %}
+
 {% block facet_list_heading %}
   {% with items = items or h.get_facet_items_dict(name) %}
   <h2 class="module-heading">
@@ -28,6 +30,9 @@
     <nav>
       <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
         {% for item in items %}
+          {% set scheming_choices = h.scheming_field_by_name(fields, name).choices or None%}
+          {% do item.update({'display_name': h.scheming_choices_label(scheming_choices, item.display_name)}) if scheming_choices %}
+
           {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
           {% set label = label_function(item) if label_function else item.display_name %}
           {% set label_truncated = h.truncate(label, 22) if not label_function else label %}

--- a/ckanext/extrafields/templates/snippets/facet_list.html
+++ b/ckanext/extrafields/templates/snippets/facet_list.html
@@ -1,0 +1,60 @@
+{#
+  facet_list_heading block changed to add screenreader text to clarify which filters are active and which ones are not.
+#}
+
+{% ckan_extends %}
+
+{% set hide_empty = true %}
+
+{% block facet_list_heading %}
+  {% with items = items or h.get_facet_items_dict(name) %}
+  <h2 class="module-heading">
+    <i class="fa fa-filter"></i>
+    {% set title = title or h.get_facet_title(name) %}
+    {{ title }}
+    {% set screen_reader_text = "No search filters applied for "+title+". Options are " %}
+    {% if items %}
+      {% if (items|selectattr("active")|list|length) > 0 %}
+        {% set screen_reader_text = "Search filters are applied for "+title+"." %}
+      {% endif %}               
+    {% endif %} 
+  </h2>
+  <span class="accessibly-hidden">{{screen_reader_text}}</span>
+  {% endwith %}
+{% endblock %}
+{% block facet_list_items %}
+  {% with items = items or h.get_facet_items_dict(name) %}
+  {% if items %}
+    <nav>
+      <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
+        {% for item in items %}
+          {% set href = h.remove_url_param(name, item.name, extras=extras, alternative_url=alternative_url) if item.active else h.add_url_param(new_params={name: item.name}, extras=extras, alternative_url=alternative_url) %}
+          {% set label = label_function(item) if label_function else item.display_name %}
+          {% set label_truncated = h.truncate(label, 22) if not label_function else label %}
+          {% set count = count_label(item['count']) if count_label else ('(%d)' % item['count']) %}
+            <li class="{{ nav_item_class or 'nav-item' }}{% if item.active %} active{% endif %}">
+              {% if item.active %}
+                <span class="accessibly-hidden">Filtered on</span>
+              {% endif %}                  
+              <a href="{{ href }}" title="{{ label if label != label_truncated else '' }}">
+                <span>{{ label_truncated }} {{ count }}</span>
+              </a>
+            </li>
+        {% endfor %}
+      </ul>
+    </nav>
+
+    <p class="module-footer">
+      {% if h.get_param_int('_%s_limit' % name) %}
+        {% if h.has_more_facets(name) %}
+          <a href="{{ h.remove_url_param('_%s_limit' % name, replace=0, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show More {facet_type}').format(facet_type=title) }}</a>
+        {% endif %}
+      {% else %}
+        <a href="{{ h.remove_url_param('_%s_limit' % name, extras=extras, alternative_url=alternative_url) }}" class="read-more">{{ _('Show Only Popular {facet_type}').format(facet_type=title) }}</a>
+      {% endif %}
+    </p>
+  {% else %}
+    <p class="module-content empty">{{ _('There are no {facet_type} that match this search').format(facet_type=title) }}</p>
+  {% endif %}
+  {% endwith %}
+{% endblock %}


### PR DESCRIPTION
Add search facets (filters) for dataset status and update frequency.

Add search sort option for recently created datasets. Recently updated is already available.

Moving facet_list.html to this extension and removing from theme as I'm starting to pull in the schema and given how these 2 extensions are separated it felt to better align with the responsibilities of this extension. It may be a good idea in the future to better separate responsibilities or to merge these 2 extensions.