### PR TITLE
Bug: When loading org page throws error.

### DIFF
--- a/ckanext/extrafields/plugin.py
+++ b/ckanext/extrafields/plugin.py
@@ -50,3 +50,19 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         facets_dict['access_level'] = toolkit._('Access Level')
         facets_dict['update_frequency'] = toolkit._('Update Frequency')
         return facets_dict
+
+    def group_facets(self, facets_dict, group_type, package_type):
+        u'''Modify and return the ``facets_dict`` for a group's page.
+        Throws AttributeError: no attribute 'organization_facets' without function.
+        '''
+        facets_dict['access_level'] = toolkit._('Access Level')
+        facets_dict['update_frequency'] = toolkit._('Update Frequency')
+        return facets_dict
+
+    def organization_facets(self, facets_dict, organization_type, package_type):
+        u'''Modify and return the ``facets_dict`` for an organization's page.
+        Throws AttributeError: no attribute 'organization_facets' without function.
+        '''
+        facets_dict['access_level'] = toolkit._('Access Level')
+        facets_dict['update_frequency'] = toolkit._('Update Frequency')
+        return facets_dict


### PR DESCRIPTION
When user went to an organization page a server error was shown.
This was due to an AttributeError being raised because IFacets couldn't
find the the group_facets() and organization_facets() functions.

CKAN doesn't check to see if the functions are implemented, only
that IFacet is implemented in an extension and then calls the
extensions.*_facets() function. So these must be set even if not modifying
the facet (e.g. `pass`). In my case I am fine with modifying the facets here as well.