### PR TITLE
Filter datasets by those with resources.

### DIFF
--- a/ckanext/extrafields/plugin.py
+++ b/ckanext/extrafields/plugin.py
@@ -4,6 +4,8 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan.common import config
+import logging
+log = logging.getLogger(__name__)
 
 def default_locale():
     '''Wrap the ckan default locale in a helper function to access
@@ -19,6 +21,7 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IFacets)
+    plugins.implements(plugins.IPackageController)
 
     def get_helpers(self):
         '''Register the helper to access the default local.
@@ -49,6 +52,7 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         '''
         facets_dict['access_level'] = toolkit._('Access Level')
         facets_dict['update_frequency'] = toolkit._('Update Frequency')
+        facets_dict['num_resources'] = toolkit._('Number of Resources (data)')
         return facets_dict
 
     def group_facets(self, facets_dict, group_type, package_type):
@@ -66,3 +70,49 @@ class ExtrafieldsPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
         facets_dict['access_level'] = toolkit._('Access Level')
         facets_dict['update_frequency'] = toolkit._('Update Frequency')
         return facets_dict
+
+    def before_search(self, search_params):
+        u'''Extensions will receive a dictionary with the query parameters,
+        and should return a modified (or not) version of it.
+        '''
+        log.error(search_params)
+        for (param, value) in search_params.items():
+            if param == 'fq' and 'num_resources:"[' in value:
+                v = value.replace('"', '')
+                search_params[param] = v
+
+        log.error(search_params)
+        return search_params
+
+    def after_search(self, search_results, search_params):
+        return search_results
+
+    def before_index(self, pkg_dict):
+        return pkg_dict
+
+    def before_view(self, pkg_dict):
+        return pkg_dict
+
+    def read(self, entity):
+        return entity
+
+    def create(self, entity):
+        return entity
+
+    def edit(self, entity):
+        return entity
+
+    def delete(self, entity):
+        return entity
+
+    def after_create(self, context, pkg_dict):
+        return pkg_dict
+
+    def after_update(self, context, pkg_dict):
+        return pkg_dict
+
+    def after_delete(self, context, pkg_dict):
+        return pkg_dict
+
+    def after_show(self, context, pkg_dict):
+        return pkg_dict

--- a/ckanext/extrafields/templates/package/search.html
+++ b/ckanext/extrafields/templates/package/search.html
@@ -20,7 +20,56 @@ Override CKAN's search.html to add new sorting options.
     (_('Name Descending'), 'title_string desc'),
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Recently Created'), 'dataset_published_date desc'),
+    (_('Datasets With Data'), 'num_resources desc, metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
   %}
   {% snippet 'snippets/search_form.html', form_id='dataset-search-form', type=dataset_type, query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, placeholder=_('Search ' + dataset_type + 's') + '...', facets=facets, show_empty=request.params, error=c.query_error, fields=c.fields %}
+
 {% endblock %}
+
+
+{% block secondary_content %}
+  <div class="filters">
+
+    <div>
+      <section class="module module-narrow module-shallow">
+        {% block facet_list_heading %}
+          <h2 class="module-heading">
+            <i class="fa fa-filter"></i>
+            {% set title = 'Resources (data)' %}
+            {{ title }}
+          </h2>
+        {% endblock %}
+        {% block facet_list_items %}
+          {% set title = 'Has Resources (data)' %}
+          <nav>
+            <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
+              {% set href = h.add_url_param(new_params={'num_resources': '[1 TO *]' },
+                                            alternative_url=alternative_url) %}
+              <li class="{{ nav_item_class or 'nav-item' }}">
+                <a href="{{ href }}" title="{{ title }}">
+                  <span>{{ title }}</span>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        {% endblock %}
+      </section>
+    </div>
+
+
+
+
+
+
+
+
+  <div>
+    {% for facet in c.facet_titles %}
+      {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet) }}
+    {% endfor %}
+  </div>
+  <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span class="text">close</span></a>
+</div>
+{% endblock %}
+

--- a/ckanext/extrafields/templates/package/search.html
+++ b/ckanext/extrafields/templates/package/search.html
@@ -30,7 +30,6 @@ Override CKAN's search.html to add new sorting options.
 
 {% block secondary_content %}
   <div class="filters">
-
     <div>
       <section class="module module-narrow module-shallow">
         {% block facet_list_heading %}
@@ -44,9 +43,13 @@ Override CKAN's search.html to add new sorting options.
           {% set title = 'Has Resources (data)' %}
           <nav>
             <ul class="{{ nav_class or 'list-unstyled nav nav-simple nav-facet' }}">
-              {% set href = h.add_url_param(new_params={'num_resources': '[1 TO *]' },
-                                            alternative_url=alternative_url) %}
-              <li class="{{ nav_item_class or 'nav-item' }}">
+              {% set href = h.remove_url_param('num_resources',
+                                               extras=extras,
+                                               alternative_url=alternative_url) 
+                            if c.fields_grouped['num_resources'] 
+                            else h.add_url_param(new_params={'num_resources': '[1 TO *]' },
+                                                alternative_url=alternative_url) %}
+              <li class="{{ nav_item_class or 'nav-item' }}{% if c.fields_grouped['num_resources'] %} active{% endif %}">
                 <a href="{{ href }}" title="{{ title }}">
                   <span>{{ title }}</span>
                 </a>

--- a/ckanext/extrafields/tests/test_before_search.py
+++ b/ckanext/extrafields/tests/test_before_search.py
@@ -1,0 +1,39 @@
+# encoding: utf-8
+
+'''Unit tests for extrafields/tests/test_before_search.py.
+'''
+
+import nose.tools
+assert_equals = nose.tools.assert_equals
+from ckanext.extrafields.plugin import (
+  num_resources_filter_scrub
+)
+
+class TestBeforeSearch(object):
+  def test_before_search_with_good_value(self):
+    u'''If search_params given num_resources remove double quotes around
+    range.
+    '''
+    search_params = {'fq': u'num_resources:"[1 TO *]"', 'rows': 20, 'facet.field': [u'organization', u'groups', u'tags', u'res_format', u'license_id', 'access_level', 'update_frequency'], 'q': u'', 'start': 0, 'extras': {}, 'include_private': True}
+    assert_equals(num_resources_filter_scrub(search_params),
+                  {'fq': u'num_resources:[1 TO *]',
+                   'rows': 20,
+                   'facet.field': [u'organization',
+                                   u'groups',
+                                   u'tags',
+                                   u'res_format',
+                                   u'license_id',
+                                   'access_level',
+                                   'update_frequency'],
+                   'q': u'',
+                   'start': 0,
+                   'extras': {},
+                   'include_private': True})
+
+  def test_before_search_with_bad_value(self):
+    u'''If search_params given num_resources with value other than "[1
+    TO *]" do not modify.
+    '''
+    search_params = {'fq': u'num_resources:"[2 TO *]"', 'rows': 20, 'facet.field': [u'organization', u'groups', u'tags', u'res_format', u'license_id', 'access_level', 'update_frequency'], 'q': u'', 'start': 0, 'extras': {}, 'include_private': True}
+    assert_equals(num_resources_filter_scrub(search_params),
+                  search_params)


### PR DESCRIPTION
**Goal:**

A user should be able to filter the search results (datasets) by those that have resources.

**Main Changes:**

- Add new filter on datasets that allow user to toggle between datasets with resources only or all datasets
- Function added to fix escaping issues in solr fq range used to filter datasets this way.
- Tests included